### PR TITLE
Use M2E p2 repo on eclipse.org instead of takari.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <repositories>
     <repository>
       <id>m2e-tests</id>
-      <url>http://repository.tesla.io:8081/nexus/content/sites/m2e.extras/m2e/1.5.0/N/LATEST/</url>
+      <url>http://download.eclipse.org/technology/m2e/milestones/1.5/</url>
       <layout>p2</layout>
     </repository>
   </repositories>


### PR DESCRIPTION
Due to https://bugs.eclipse.org/bugs/show_bug.cgi?id=433653, it's better to build m2eclipse-tycho against http://download.eclipse.org/technology/m2e/milestones/1.5/ p2 repo on eclipse.org than the http://repository.takari.io:8081/nexus/content/sites/m2e.extras/m2e/1.5.0/N/LATEST/ (which is currently down) ?
