### PR TITLE
Upgraded from Tycho 0.18.1 to 0.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <tychoVersion>0.18.1</tychoVersion>  
+    <tychoVersion>0.20.0</tychoVersion>  
     <repositoryPathId>m2eclipse-tycho</repositoryPathId>
     <p2MetadataName>Tycho Project Configurators Update Site</p2MetadataName>
     <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m</tycho.test.jvmArgs>


### PR DESCRIPTION
Upgrade from Tycho 0.18.1 to 0.20.0.

Probably a good idea in general. I have NOT done ANY tests - but this does still build.

Actual motivation for change was that on https://vorburger.ci.cloudbees.com/job/m2eclipse-tycho/1/ I've run into the https://dev.eclipse.org/mhonarc/lists/egit-dev/msg02554.html => https://bugs.eclipse.org/bugs/show_bug.cgi?id=317785 story, and I was hoping that newer Tycho would pull newer Equinox and avoid this problem (I have not yet verified that; the workaround seems to be to specify -Djava.util.Arrays.useLegacyMergeSort=true as MAVEN_OPTS).
