### PR TITLE
No longer bind maven-bundle-plugin goals from version 3.2.0

### DIFF
--- a/org.sonatype.tycho.m2e/lifecycle-mapping-metadata.xml
+++ b/org.sonatype.tycho.m2e/lifecycle-mapping-metadata.xml
@@ -102,7 +102,7 @@
       <pluginExecutionFilter>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <versionRange>[1.0.0,)</versionRange>
+        <versionRange>[1.0.0,3.2.0)</versionRange>
         <goals>
           <goal>manifest</goal>
           <goal>bundle</goal>
@@ -118,7 +118,7 @@
       <pluginExecutionFilter>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <versionRange>[1.0.0,)</versionRange>
+        <versionRange>[1.0.0,3.2.0)</versionRange>
         <goals>
           <goal>manifest</goal>
           <goal>bundle</goal>
@@ -134,7 +134,7 @@
       <pluginExecutionFilter>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <versionRange>[1.0.0,)</versionRange>
+        <versionRange>[1.0.0,3.2.0)</versionRange>
         <goals>
           <goal>cleanVersions</goal>
         </goals>


### PR DESCRIPTION
Version 3.2.0 natively supports m2e
(https://issues.apache.org/jira/browse/FELIX-4009).

This closes #31